### PR TITLE
Resolve default options on database load

### DIFF
--- a/extension/src/database.ts
+++ b/extension/src/database.ts
@@ -1,13 +1,38 @@
-import { Database, isDatabase } from './types/database'
+import { Database, defaultDatabase, isDatabase } from './types/database'
+
+const optionalBool = (bool: boolean | undefined | null, defaultValue: boolean): boolean => {
+  if (bool === undefined || bool === null) {
+    return defaultValue
+  }
+
+  return bool
+}
 
 export const getDatabase = async (): Promise<Database> => {
   const result = await chrome.storage.local.get('database')
 
-  if (!isDatabase(result.database)) {
-    throw new Error('The database has not been initialized')
+  if (!result || !result.database) {
+    return defaultDatabase
   }
 
-  return result.database
+  // We have loaded something that may have been saved with an old version, so this is not fun but it allows us to have defaults and migration path.
+  const uncheckedDatabase = result.database as any
+
+  try {
+    const database: Database = {
+      weeks: uncheckedDatabase?.weeks || {},
+      options: {
+        dailyTimeEntryReminder: optionalBool(uncheckedDatabase?.options?.dailyTimeEntryReminder, true),
+        endOfWeekTimesheetReminder: optionalBool(uncheckedDatabase?.options?.endOfWeekTimesheetReminder, true),
+        gifDataUrl: uncheckedDatabase?.options?.gifDataUrl || null,
+        soundDataUrl: uncheckedDatabase?.option?.soundDataUrl || null,
+      },
+    }
+
+    return database
+  } catch (e) {
+    return defaultDatabase
+  }
 }
 
 export const initializeDatabase = async () => {
@@ -17,18 +42,7 @@ export const initializeDatabase = async () => {
     return
   }
 
-  // todo: revisit defaults
-  const database: Database = {
-    weeks: {},
-    options: {
-      endOfWeekTimesheetReminder: true,
-      dailyTimeEntryReminder: true,
-      soundDataUrl: null,
-      gifDataUrl: null,
-    },
-  }
-
-  await chrome.storage.local.set({ database })
+  await chrome.storage.local.set({ database: defaultDatabase })
 }
 
 export const saveDatabase = async (database: Database): Promise<void> => {

--- a/extension/src/types/database.ts
+++ b/extension/src/types/database.ts
@@ -39,6 +39,16 @@ export interface Database {
   options: Options
 }
 
+export const defaultDatabase: Database = {
+  weeks: {},
+  options: {
+    dailyTimeEntryReminder: true,
+    endOfWeekTimesheetReminder: true,
+    gifDataUrl: null,
+    soundDataUrl: null,
+  },
+}
+
 export interface DatabaseInformation {
   database: Database
   isDatabaseInitialized: boolean


### PR DESCRIPTION
Prior to this commit, we were resolving the default option values when initializing the database. However, this won't work since we might be dealing with an option that was added in a new version of the extension.